### PR TITLE
Update Dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    cron: 0 16 21 * *
+  groups:
+    github-actions:
+      patterns:
+      - '*'


### PR DESCRIPTION

## Summary
                
This PR updates the Dependabot configuration to run monthly on the 21 day at 4 pm GMT. It also 
updates the Dependabot configuration to include all GitHub Actions workflows.
