### PR TITLE
Refactor build-android Workflows for GitHub Actions Updates

### DIFF
--- a/.github/workflows/build-android-app.yml
+++ b/.github/workflows/build-android-app.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [ "*" ]
   pull_request:
-    branches: [ "master" , "develop" ]
+    branches: [ "master", "develop" ]
 
 permissions:
   contents: read
@@ -25,24 +25,23 @@ jobs:
     - name: initialize gradle
       run: gradle init
     - name: Create secret-file.txt from B64_SECRET1
-      id: secret-file1
       run: |
         $secretFile = Join-Path -Path $env:GITHUB_WORKSPACE -ChildPath "app/smile_config.json";
         $encodedBytes = [System.Convert]::FromBase64String($env:SECRET_DATA1);
         Set-Content $secretFile -Value $encodedBytes -AsByteStream;
         $secretFileHash = Get-FileHash $secretFile;
-        Write-Output "::set-output name=SECRET_FILE::$secretFile";
-        Write-Output "::set-output name=SECRET_FILE_HASH::$($secretFileHash.Hash)";
+        echo "SECRET_FILE=$secretFile" >> $GITHUB_ENV;
+        echo "SECRET_FILE_HASH=$($secretFileHash.Hash)" >> $GITHUB_ENV;
       shell: pwsh
       env:
         SECRET_DATA1: ${{ secrets.B64_SECRET1 }}
     - name: "Get branch name and save to env"
-      if: ${{ github.EVENT_NAME == 'pull_request' }}
+      if: ${{ github.event_name == 'pull_request' }}
       run: |
           BRANCH_NAME="${GITHUB_HEAD_REF}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
     - name: "Get branch name and save to env"
-      if: ${{ github.EVENT_NAME == 'push' }}
+      if: ${{ github.event_name == 'push' }}
       run: |
           BRANCH_NAME="${GITHUB_REF##*/}"
           echo "BRANCH_NAME=${BRANCH_NAME}" >> $GITHUB_ENV
@@ -59,5 +58,4 @@ jobs:
       shell: pwsh
       if: always()
       env:
-        SECRET_FILE: ${{ steps.secret-file1.outputs.SECRET_FILE }}
-    
+        SECRET_FILE: ${{ env.SECRET_FILE }}

--- a/.github/workflows/build-android-app.yml
+++ b/.github/workflows/build-android-app.yml
@@ -52,9 +52,18 @@ jobs:
         SID_AWS_BUCKET: ${{ secrets.SID_AWS_BUCKET }}
         SID_AWS_REGION: ${{ secrets.SID_AWS_REGION }}
         SLACK_URL: ${{ secrets.SLACK_URL }}
+    - name: Debug secret file path
+      run: |
+        Write-Host "SECRET_FILE is: $env:SECRET_FILE"
+      shell: pwsh
+      if: always()
     - name: Delete secret file
       run: |
-        Remove-Item -Path $env:SECRET_FILE;
+        if (Test-Path -Path $env:SECRET_FILE) {
+          Remove-Item -Path $env:SECRET_FILE;
+        } else {
+          Write-Host "SECRET_FILE environment variable is not set or points to a non-existent file.";
+        }
       shell: pwsh
       if: always()
       env:

--- a/.github/workflows/build-android-manually.yml
+++ b/.github/workflows/build-android-manually.yml
@@ -40,24 +40,21 @@ jobs:
     - name: initialize gradle
       run: gradle init
     - name: Create secret-file.txt from B64_SECRET1
-      id: secret-file1
       run: |
         $secretFile = Join-Path -Path $env:RUNNER_TEMP -ChildPath "smile_config.json";
         $encodedBytes = [System.Convert]::FromBase64String($env:SECRET_DATA1);
         Set-Content $secretFile -Value $encodedBytes -AsByteStream;
         $secretFileHash = Get-FileHash $secretFile;
-        Write-Output "::set-output name=SECRET_FILE::$secretFile";
-        Write-Output "::set-output name=SECRET_FILE_HASH::$($secretFileHash.Hash)";
-        Write-Output "Secret file $secretFile has hash $($secretFileHash.Hash)";
+        echo "SECRET_FILE=$secretFile" >> $GITHUB_ENV
+        echo "SECRET_FILE_HASH=$($secretFileHash.Hash)" >> $GITHUB_ENV
+        Write-Host "Secret file $secretFile has hash $($secretFileHash.Hash)";
       shell: pwsh
       env:
         SECRET_DATA1: ${{ secrets.B64_SECRET1 }}
     - name: Delete secret file
-      run: |
-        Remove-Item -Path $env:SECRET_FILE;
-        shell: pwsh
-        if: always()
-        env:
-          SECRET_FILE: ${{ steps.secret-file1.outputs.SECRET_FILE }}
+      run: Remove-Item -Path $env:SECRET_FILE;
+      shell: pwsh
+      if: always()
+      env:
+        SECRET_FILE: ${{ env.SECRET_FILE }}
     - run: fastlane android deploy_beta
-    


### PR DESCRIPTION
This PR updates the `build-android` GitHub Actions workflows, replacing the deprecated `::set-output` command with the `$GITHUB_ENV` method for setting environment variables. 